### PR TITLE
Fix unrecoverable error on fresh install

### DIFF
--- a/ting_marc.admin.inc
+++ b/ting_marc.admin.inc
@@ -231,6 +231,14 @@ function ting_marc_delete_item_confirm_submit($form, &$form_state) {
  */
 function ting_marc_types() {
   $ting_well_types = variable_get('ting_well_types', array());
+
+  // If we don't have any well types they might not have been fetched yet.
+  // TODO: Maybe it should be possible to update the well types on the form
+  // instead. Like it's done in ting module.
+  if (empty($ting_well_types)) {
+    $ting_well_types = _ting_fetch_well_types();
+  }
+
   $type_arr = drupal_map_assoc(array_keys($ting_well_types));
 
   array_walk($type_arr, function (&$item) {

--- a/ting_marc.install
+++ b/ting_marc.install
@@ -8,7 +8,9 @@
  * Implements hook_install.
  */
 function ting_marc_install() {
-  features_feature_lock('ting_material_details', 'field_group');
+  if (version_compare(_ting_marc_get_features_version(), '2.1', '>=')) {
+    features_feature_lock('ting_material_details', 'field_group');
+  }
 }
 
 /**
@@ -22,6 +24,19 @@ function _ting_marc_resave_fields() {
       ting_marc_create_field((array) $marc_field);
     }
   }
+}
+
+/**
+ * Returns the version of the currently installed Features module.
+ */
+function _ting_marc_get_features_version() {
+  $features_info = system_get_info('module', 'features');
+  if (!empty($features_info['version'])) {
+    // Lose the 7.x-
+    $features_version = explode('-', $features_info['version']);
+    return $features_version[1];
+  }
+  return '0';
 }
 
 /**
@@ -178,6 +193,8 @@ function ting_marc_update_7004() {
  * Locking field_group component of ting_material_details feature.
  */
 function ting_marc_update_7005() {
-  features_feature_lock('ting_material_details', 'field_group');
+  if (version_compare(_ting_marc_get_features_version(), '2.1', '>=')) {
+    features_feature_lock('ting_material_details', 'field_group');
+  }
   _ting_marc_resave_fields();
 }

--- a/ting_marc.install
+++ b/ting_marc.install
@@ -8,7 +8,6 @@
  * Implements hook_install.
  */
 function ting_marc_install() {
-  _ting_fetch_well_types();
   features_feature_lock('ting_material_details', 'field_group');
 }
 


### PR DESCRIPTION
This PR fixes some stuff that gives error on install:

1. It tries to fetch well types before we have a chance to configure ting endpoints, resulting in error on site-install which will then not complete. Especially a problem regarding automatic builds in CI.

2. It tries to lock features without checking if this is supported in the current version. This is a problem since the lock features was added in 2.1 and 2.0 is still used on a lot of installs. 
In fact Features was just recently updated here and hasn't even been tested yet: https://platform.dandigbib.org/issues/3289

In retrospect I could just have used function_exists to solve 2., but it works this way so decided just to leave it be.